### PR TITLE
Simplify share token management

### DIFF
--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -12,7 +12,6 @@ type ShareTokenRow = {
   id: string;
   group_id: string;
   disabled: boolean;
-  expires_at: string | null;
   groups?: {
     id: string;
     name: string;
@@ -55,7 +54,6 @@ export default async function SharePage({
         id,
         group_id,
         disabled,
-        expires_at,
         groups (
           id,
           name
@@ -71,11 +69,7 @@ export default async function SharePage({
     notFound();
   }
 
-  const expiresAt = shareToken.expires_at
-    ? new Date(shareToken.expires_at)
-    : null;
-
-  if (shareToken.disabled || (expiresAt && expiresAt < new Date())) {
+  if (shareToken.disabled) {
     notFound();
   }
 

--- a/components/GroupEdit/GroupEdit.tsx
+++ b/components/GroupEdit/GroupEdit.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCategories } from '@/lib/contexts/CategoriesContext';
-import { useGroups } from '@/lib/contexts/GroupsContext'; // <-- updated import
+import { useGroups } from '@/lib/contexts/GroupsContext';
 import { useMembers } from '@/lib/contexts/MembersContext';
 import { useTokens } from '@/lib/contexts/TokensContext';
 import { useShareTokens } from '@/lib/contexts/ShareTokensContext';
@@ -13,7 +13,7 @@ export function GroupEdit() {
   const { currentGroup } = useGroups();
   const { members, updateMembers } = useMembers();
   const { tokens, addToken } = useTokens();
-  const { shareTokens, addShareToken, revokeShareToken } = useShareTokens();
+  const { shareToken, enableShareToken, disableShareToken } = useShareTokens();
   const [tempMembers, setTempMembers] = useState(members);
   const newMemberInputRef = useRef<HTMLInputElement>(null);
 
@@ -199,14 +199,11 @@ export function GroupEdit() {
             Anyone with these links can view the group&apos;s expenses without
             needing an account.
           </p>
-          <div>
-            {shareTokens.map((token) => (
-              <div
-                key={token.id}
-                className="flex flex-wrap items-center gap-2 max-w-xl py-2"
-              >
+          {shareToken ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2 max-w-xl py-2">
                 <Input
-                  value={`${process.env.NEXT_PUBLIC_BASE_URL}/share/${token.id}`}
+                  value={`${process.env.NEXT_PUBLIC_BASE_URL}/share/${shareToken.id}`}
                   readOnly
                   className="flex-1"
                 />
@@ -215,33 +212,45 @@ export function GroupEdit() {
                   variant="ghost"
                   onClick={async () => {
                     await navigator.clipboard.writeText(
-                      `${process.env.NEXT_PUBLIC_BASE_URL}/share/${token.id}`,
+                      `${process.env.NEXT_PUBLIC_BASE_URL}/share/${shareToken.id}`,
                     );
                   }}
                 >
                   Copy
                 </Button>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Status: {shareToken.disabled ? 'Disabled' : 'Enabled'}
+              </p>
+              <div className="flex items-center space-x-2 max-w-md">
                 <Button
                   type="button"
-                  variant="ghost"
-                  onClick={() => revokeShareToken(token.id)}
+                  className="w-full"
+                  onClick={() => {
+                    if (shareToken.disabled) {
+                      enableShareToken(currentGroup.id);
+                    } else {
+                      disableShareToken(shareToken.id);
+                    }
+                  }}
                 >
-                  Disable
+                  {shareToken.disabled ? 'Enable Share Link' : 'Disable Share Link'}
                 </Button>
               </div>
-            ))}
-          </div>
-          <div className="flex items-center space-x-2 max-w-md">
-            <Button
-              type="button"
-              className="w-full"
-              onClick={() => {
-                addShareToken(currentGroup.id);
-              }}
-            >
-              Create Share Link
-            </Button>
-          </div>
+            </>
+          ) : (
+            <div className="flex items-center space-x-2 max-w-md">
+              <Button
+                type="button"
+                className="w-full"
+                onClick={() => {
+                  enableShareToken(currentGroup.id);
+                }}
+              >
+                Enable Share Link
+              </Button>
+            </div>
+          )}
         </div>
       </TabsContent>
     </Tabs>

--- a/components/GroupEdit/GroupEdit.tsx
+++ b/components/GroupEdit/GroupEdit.tsx
@@ -230,7 +230,7 @@ export function GroupEdit() {
                     if (shareToken.disabled) {
                       enableShareToken(currentGroup.id);
                     } else {
-                      disableShareToken(shareToken.id);
+                      disableShareToken(currentGroup.id);
                     }
                   }}
                 >

--- a/components/Groups/GroupDetail.tsx
+++ b/components/Groups/GroupDetail.tsx
@@ -14,7 +14,7 @@ import { useShareTokens } from '@/lib/contexts/ShareTokensContext';
 import { getExpenses } from '@/lib/db/expenses';
 import { getMembers } from '@/lib/db/members';
 import { getActiveTokens } from '@/lib/db/tokens';
-import { getActiveShareTokens } from '@/lib/db/shareTokens';
+import { getShareToken } from '@/lib/db/shareTokens';
 
 export function GroupDetail({ groupId }: { groupId: string }) {
   const { currentGroup, getGroupDetail } = useGroups();
@@ -23,7 +23,7 @@ export function GroupDetail({ groupId }: { groupId: string }) {
   const { set: setExpenses } = useExpensesStore();
   const { updateMembers } = useMembers();
   const { setTokens } = useTokens();
-  const { setShareTokens } = useShareTokens();
+  const { setShareToken } = useShareTokens();
 
   useEffect(() => {
     const initExpenses = async () => {
@@ -38,9 +38,9 @@ export function GroupDetail({ groupId }: { groupId: string }) {
       const tokens = await getActiveTokens(groupId);
       setTokens(tokens);
     };
-    const initShareTokens = async () => {
-      const tokens = await getActiveShareTokens(groupId);
-      setShareTokens(tokens);
+    const initShareToken = async () => {
+      const token = await getShareToken(groupId);
+      setShareToken(token);
     };
 
     getGroupDetail(groupId);
@@ -48,7 +48,7 @@ export function GroupDetail({ groupId }: { groupId: string }) {
     initExpenses();
     initMembers();
     initTokens();
-    initShareTokens();
+    initShareToken();
   }, [
     groupId,
     getGroupDetail,
@@ -56,7 +56,7 @@ export function GroupDetail({ groupId }: { groupId: string }) {
     setExpenses,
     updateMembers,
     setTokens,
-    setShareTokens,
+    setShareToken,
   ]);
 
   if (!currentGroup) {

--- a/lib/contexts/ShareTokensContext.tsx
+++ b/lib/contexts/ShareTokensContext.tsx
@@ -9,7 +9,7 @@ type ShareTokensContextType = {
   shareToken: ShareToken | null;
   setShareToken: (token: ShareToken | null) => void;
   enableShareToken: (groupId: string) => Promise<void>;
-  disableShareToken: (tokenId: string) => Promise<void>;
+  disableShareToken: (groupId: string) => Promise<void>;
 };
 
 const ShareTokensContext =
@@ -29,8 +29,8 @@ export const ShareTokensProvider: React.FC<{ children: React.ReactNode }> = ({
     setShareTokenState(token);
   }, []);
 
-  const disableShareToken = useCallback(async (tokenId: string) => {
-    const token = await disableShareTokenDb(tokenId);
+  const disableShareToken = useCallback(async (groupId: string) => {
+    const token = await disableShareTokenDb(groupId);
     setShareTokenState(token);
   }, []);
 

--- a/lib/contexts/ShareTokensContext.tsx
+++ b/lib/contexts/ShareTokensContext.tsx
@@ -1,15 +1,15 @@
 import React, { createContext, useCallback, useContext, useState } from 'react';
 import { ShareToken } from '@/lib/types';
 import {
-  createShareToken,
-  disableShareToken,
+  disableShareToken as disableShareTokenDb,
+  enableShareToken as enableShareTokenDb,
 } from '@/lib/db/shareTokens';
 
 type ShareTokensContextType = {
-  shareTokens: ShareToken[];
-  setShareTokens: (tokens: ShareToken[]) => void;
-  addShareToken: (groupId: string) => Promise<void>;
-  revokeShareToken: (tokenId: string) => Promise<void>;
+  shareToken: ShareToken | null;
+  setShareToken: (token: ShareToken | null) => void;
+  enableShareToken: (groupId: string) => Promise<void>;
+  disableShareToken: (tokenId: string) => Promise<void>;
 };
 
 const ShareTokensContext =
@@ -18,21 +18,30 @@ const ShareTokensContext =
 export const ShareTokensProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [shareTokens, setShareTokens] = useState<ShareToken[]>([]);
+  const [shareToken, setShareTokenState] = useState<ShareToken | null>(null);
 
-  const addShareToken = useCallback(async (groupId: string) => {
-    const token = await createShareToken(groupId);
-    setShareTokens((prev) => [...prev, token]);
+  const setShareToken = useCallback((token: ShareToken | null) => {
+    setShareTokenState(token);
   }, []);
 
-  const revokeShareToken = useCallback(async (tokenId: string) => {
-    await disableShareToken(tokenId);
-    setShareTokens((prev) => prev.filter((token) => token.id !== tokenId));
+  const enableShareToken = useCallback(async (groupId: string) => {
+    const token = await enableShareTokenDb(groupId);
+    setShareTokenState(token);
+  }, []);
+
+  const disableShareToken = useCallback(async (tokenId: string) => {
+    const token = await disableShareTokenDb(tokenId);
+    setShareTokenState(token);
   }, []);
 
   return (
     <ShareTokensContext.Provider
-      value={{ shareTokens, setShareTokens, addShareToken, revokeShareToken }}
+      value={{
+        shareToken,
+        setShareToken,
+        enableShareToken,
+        disableShareToken,
+      }}
     >
       {children}
     </ShareTokensContext.Provider>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,5 +42,4 @@ export type ShareToken = {
   disabled: boolean;
   groupId: string;
   createdAt: Date;
-  expiresAt: Date | null;
 };


### PR DESCRIPTION
## Summary
- ensure share tokens are created once per group and toggled via enable/disable instead of expiration
- update the share token context and editor UI to work with a single persistent share link
- remove expiration handling from the shared view page and share token type definitions

## Testing
- yarn lint *(fails: workspace package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68f18f3a58748325a419f1177045e653