### PR TITLE
Optimize expense split settlements

### DIFF
--- a/lib/utils/expenseSplit.ts
+++ b/lib/utils/expenseSplit.ts
@@ -2,45 +2,88 @@ import type { Expense } from '@/lib/types';
 
 export type SplitDetails = Record<string, Record<string, number>>;
 
-export function calculateSplitDetails(expenses: Expense[]): SplitDetails {
-  const splitDetails = expenses.reduce<SplitDetails>((acc, expense) => {
-    expense.participants.forEach((participant) => {
-      if (!expense.handledBy?.id || expense.handledBy?.id === participant.id) {
-        return;
-      }
-      const handledById = expense.handledBy?.id;
-      if (!handledById) return;
+const EPSILON = 0.01;
 
-      acc[participant.id] = {
-        ...acc[participant.id],
-        [handledById]:
-          (acc[participant.id]?.[handledById] || 0) +
-          Number(expense.amount) / expense.participants.length,
-      };
+type Balance = {
+  id: string;
+  amount: number;
+};
+
+export function calculateSplitDetails(expenses: Expense[]): SplitDetails {
+  const balances = expenses.reduce<Record<string, number>>((acc, expense) => {
+    const handledById = expense.handledBy?.id;
+    if (!handledById || !expense.participants.length) {
+      return acc;
+    }
+
+    const totalAmount = Number(expense.amount);
+    const share = totalAmount / expense.participants.length;
+
+    expense.participants.forEach((participant) => {
+      acc[participant.id] = (acc[participant.id] || 0) - share;
     });
+
+    acc[handledById] = (acc[handledById] || 0) + totalAmount;
+
     return acc;
   }, {});
 
-  Object.entries(splitDetails).forEach(([participantId, details]) => {
-    Object.keys(details).forEach((payer) => {
-      if (splitDetails[payer]?.[participantId] !== undefined) {
-        const amount = Math.min(
-          splitDetails[participantId][payer],
-          splitDetails[payer][participantId],
-        );
+  const debtors: Balance[] = [];
+  const creditors: Balance[] = [];
 
-        splitDetails[participantId][payer] -= amount;
-        if (splitDetails[participantId][payer] === 0) {
-          delete splitDetails[participantId][payer];
-        }
-
-        splitDetails[payer][participantId] -= amount;
-        if (splitDetails[payer][participantId] === 0) {
-          delete splitDetails[payer][participantId];
-        }
-      }
-    });
+  Object.entries(balances).forEach(([id, amount]) => {
+    if (amount > EPSILON) {
+      creditors.push({ id, amount });
+    } else if (amount < -EPSILON) {
+      debtors.push({ id, amount: -amount });
+    }
   });
+
+  const splitDetails: SplitDetails = {};
+
+  let debtorIndex = 0;
+  let creditorIndex = 0;
+
+  while (debtorIndex < debtors.length && creditorIndex < creditors.length) {
+    const debtor = debtors[debtorIndex];
+    const creditor = creditors[creditorIndex];
+
+    const amount = Math.min(debtor.amount, creditor.amount);
+    if (amount < EPSILON) {
+      debtor.amount = 0;
+      debtorIndex += 1;
+      continue;
+    }
+
+    const roundedAmount = Math.floor(amount * 100) / 100;
+
+    if (roundedAmount < EPSILON) {
+      debtor.amount = 0;
+      debtorIndex += 1;
+      continue;
+    }
+
+    splitDetails[debtor.id] = {
+      ...splitDetails[debtor.id],
+      [creditor.id]: (splitDetails[debtor.id]?.[creditor.id] || 0) + roundedAmount,
+    };
+
+    debtor.amount = Math.max(0, parseFloat((debtor.amount - roundedAmount).toFixed(10)));
+    creditor.amount = Math.max(
+      0,
+      parseFloat((creditor.amount - roundedAmount).toFixed(10)),
+    );
+
+    if (debtor.amount <= EPSILON) {
+      debtor.amount = 0;
+      debtorIndex += 1;
+    }
+
+    if (creditor.amount <= EPSILON) {
+      creditor.amount = 0;
+      creditorIndex += 1;
+    }
+  }
 
   return splitDetails;
 }


### PR DESCRIPTION
## Summary
- compute participant balances for each expense and derive settlements from overall debts
- limit transactions to net debtors and creditors with rounding safeguards so each person settles once per counterparty
- skip expenses without a payer to match the previous behaviour

## Testing
- yarn lint *(fails: requires interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68f331734750832582435504ce6f55a6