### PR TITLE
Optimize settlement calculation to minimize transactions

### DIFF
--- a/lib/utils/expenseSplit.ts
+++ b/lib/utils/expenseSplit.ts
@@ -2,45 +2,76 @@ import type { Expense } from '@/lib/types';
 
 export type SplitDetails = Record<string, Record<string, number>>;
 
-export function calculateSplitDetails(expenses: Expense[]): SplitDetails {
-  const splitDetails = expenses.reduce<SplitDetails>((acc, expense) => {
-    expense.participants.forEach((participant) => {
-      if (!expense.handledBy?.id || expense.handledBy?.id === participant.id) {
-        return;
-      }
-      const handledById = expense.handledBy?.id;
-      if (!handledById) return;
+type Balance = {
+  id: string;
+  amount: number;
+};
 
-      acc[participant.id] = {
-        ...acc[participant.id],
-        [handledById]:
-          (acc[participant.id]?.[handledById] || 0) +
-          Number(expense.amount) / expense.participants.length,
-      };
+export function calculateSplitDetails(expenses: Expense[]): SplitDetails {
+  const balances = expenses.reduce<Record<string, number>>((acc, expense) => {
+    if (!expense.handledBy?.id) {
+      return acc;
+    }
+
+    const share =
+      expense.participants.length > 0
+        ? Number(expense.amount) / expense.participants.length
+        : 0;
+
+    expense.participants.forEach((participant) => {
+      acc[participant.id] = (acc[participant.id] || 0) - share;
     });
+
+    acc[expense.handledBy.id] =
+      (acc[expense.handledBy.id] || 0) + Number(expense.amount);
+
     return acc;
   }, {});
 
-  Object.entries(splitDetails).forEach(([participantId, details]) => {
-    Object.keys(details).forEach((payer) => {
-      if (splitDetails[payer]?.[participantId] !== undefined) {
-        const amount = Math.min(
-          splitDetails[participantId][payer],
-          splitDetails[payer][participantId],
-        );
+  const debtors: Balance[] = [];
+  const creditors: Balance[] = [];
 
-        splitDetails[participantId][payer] -= amount;
-        if (splitDetails[participantId][payer] === 0) {
-          delete splitDetails[participantId][payer];
-        }
+  Object.entries(balances).forEach(([id, amount]) => {
+    const roundedAmount = Math.round(amount * 100) / 100;
 
-        splitDetails[payer][participantId] -= amount;
-        if (splitDetails[payer][participantId] === 0) {
-          delete splitDetails[payer][participantId];
-        }
-      }
-    });
+    if (roundedAmount > 0) {
+      creditors.push({ id, amount: roundedAmount });
+    } else if (roundedAmount < 0) {
+      debtors.push({ id, amount: Math.abs(roundedAmount) });
+    }
   });
+
+  debtors.sort((a, b) => b.amount - a.amount);
+  creditors.sort((a, b) => b.amount - a.amount);
+
+  const splitDetails: SplitDetails = {};
+
+  let debtorIndex = 0;
+  let creditorIndex = 0;
+
+  while (debtorIndex < debtors.length && creditorIndex < creditors.length) {
+    const debtor = debtors[debtorIndex];
+    const creditor = creditors[creditorIndex];
+    const amount = Math.min(debtor.amount, creditor.amount);
+
+    if (!splitDetails[debtor.id]) {
+      splitDetails[debtor.id] = {};
+    }
+
+    splitDetails[debtor.id][creditor.id] =
+      (splitDetails[debtor.id][creditor.id] || 0) + amount;
+
+    debtor.amount -= amount;
+    creditor.amount -= amount;
+
+    if (Math.abs(debtor.amount) < 0.01) {
+      debtorIndex += 1;
+    }
+
+    if (Math.abs(creditor.amount) < 0.01) {
+      creditorIndex += 1;
+    }
+  }
 
   return splitDetails;
 }


### PR DESCRIPTION
## Summary
- replace the settlement reducer with a net balance algorithm
- minimize transactions by matching the largest debtors and creditors greedily
- keep results rounded to avoid floating point residue

## Testing
- yarn lint *(fails: workspace dependencies not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134720889c8325a574076ed9a169d4)